### PR TITLE
Explicitely unmirror Displays

### DIFF
--- a/displayplacer.c
+++ b/displayplacer.c
@@ -186,6 +186,10 @@ int main(int argc, char* argv[]) {
             isSuccess = rotateScreen(screenConfigs[i].id, screenConfigs[i].uuid, screenConfigs[i].degree) && isSuccess;
         }
 
+        if (screenConfigs[i].mirrorCount == 0) {
+            isSuccess = disableMirror(configRef, screenConfigs[i].id, screenConfigs[i].uuid) && isSuccess;
+        }
+
         for (int j = 0; j < screenConfigs[i].mirrorCount; j++) {
             screenConfigs[i].mirrors[j] = convertUUIDtoID(screenConfigs[i].mirrorUUIDs[j]);
             if (!validateScreenOnline(screenList, screenCount, screenConfigs[i].mirrors[j], screenConfigs[i].mirrorUUIDs[j], screenConfigs[i].quietMissingScreen)) {
@@ -507,6 +511,18 @@ bool configureMirror(CGDisplayConfigRef configRef, CGDirectDisplayID primaryScre
 
     return true;
 }
+
+bool disableMirror(CGDisplayConfigRef configRef, CGDirectDisplayID mirrorScreenId, char* mirrorScreenUUID) {
+    int retVal = CGConfigureDisplayMirrorOfDisplay(configRef, mirrorScreenId, kCGNullDirectDisplay);
+
+    if (retVal != 0) {
+        fprintf(stderr, "Error stop mirroring %s \n", mirrorScreenUUID);
+        return false;
+    }
+
+    return true;
+}
+
 
 bool configureResolution(CGDisplayConfigRef configRef, CGDirectDisplayID screenId, char* screenUUID, int width, int height, int hz, int depth, bool scaled, int modeNum) {
     int modeCount;

--- a/header.h
+++ b/header.h
@@ -75,5 +75,6 @@ bool validateScreenOnline(CGDirectDisplayID onlineDisplayList[], int screenCount
 bool isScreenEnabled(CGDirectDisplayID screenId);
 bool rotateScreen(CGDirectDisplayID screenId, char* screenUUID, int degree);
 bool configureMirror(CGDisplayConfigRef configRef, CGDirectDisplayID primaryScreenId, char* primaryScreenUUID, CGDirectDisplayID mirrorScreenId, char* mirrorScreenUUID);
+bool disableMirror(CGDisplayConfigRef configRef, CGDirectDisplayID mirrorScreenId, char* mirrorScreenUUID);
 bool configureResolution(CGDisplayConfigRef configRef, CGDirectDisplayID screenId, char* screenUUID, int width, int height, int hz, int depth, bool scaled, int modeNum);
 bool configureOrigin(CGDisplayConfigRef configRef, CGDirectDisplayID screenId, char* screenUUID, int x, int y);


### PR DESCRIPTION
This commit explicitely calls "stop Mirror" on display configurations which do not carry "mirror information". This is required to unmirror previously mirrored displays.

This addresses #98.